### PR TITLE
Made custom responses ignore capitalization

### DIFF
--- a/main.go
+++ b/main.go
@@ -863,7 +863,7 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	// Check if CustomResponses map contains message, reply with the according value if so
 	// response contains the actual response, whole found is used to determine if key exists in the first place
-	if response, found := CustomResponses[m.Content]; found {
+	if response, found := CustomResponses[strings.Title(m.Content)]; found {
 		reply(s, m, response)
 	}
 

--- a/state.go
+++ b/state.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 )
 
 func InitGlobal() {
@@ -66,13 +67,21 @@ func InitCustomResponses() {
 	// Errors are ignored here, as there is no way they should happen, as the existence of the file has already been tested for
 	jsonBytes, _ := ioutil.ReadAll(jsonFile)
 
+	// create a temporary map, to hold the keys before making lowercase
+	temporaryMap := make(map[string]string)
+
 	// Unmarshal into CustomResponses map
-	err = json.Unmarshal(jsonBytes, &CustomResponses)
+	err = json.Unmarshal(jsonBytes, &temporaryMap)
 
 	// Error handling in case json is invalid
 	if err != nil {
 		fmt.Println(err, ", no custom responses were loaded. custom_responses.json might be malformed.")
 		return
+	}
+
+	// Make everything lowercase
+	for k, v := range temporaryMap {
+		CustomResponses[strings.Title(k)] = v
 	}
 }
 


### PR DESCRIPTION
Custom responses defined in the custom_responses.json now ignore capitalization (it does not matter how they were written in the .json as well).

So if, as an example, the string "hello" would trigger an answer, both "hello" and "Hello" would trigger a response, while "HEllo", "heLLo" and so on would not.