### PR TITLE
Added FileWatcher so .json files can be reloaded dynamically without downtime

### DIFF
--- a/main.go
+++ b/main.go
@@ -724,7 +724,6 @@ func postInvite(s *discordgo.Session, m *discordgo.MessageCreate) {
 func init() {
 	Commands = make(map[string]BotCmd)
 	Usages = make(map[string]string)
-	CustomResponses = make(map[string]string)
 	addCommand(waifuReg, "Register your waifu with the bot", "waifureg", "husbandoreg", "setwaifu", "sethusbando", "spousereg", "setspouse")
 	addCommand(waifuDel, "Delete a previously registered waifu", "waifudel", "husbandodel", "spousedel")
 	addCommand(childDel, "Delete a previously registered child", "daughterdel", "sondel", "childdel")
@@ -752,6 +751,8 @@ func init() {
 	InitGlobal()
 	InitComforts()
 	InitCustomResponses()
+
+	AttachWatcher()
 
 	flag.StringVar(&Token, "t", "", "Bot Token")
 	flag.StringVar(&AdminID, "a", "", "Admin's Discord ID")

--- a/state.go
+++ b/state.go
@@ -97,27 +97,30 @@ func handleReload(filename string) {
 	var err error = nil      // Used for error handling/ notifying of errors
 	var changed bool = false // Used to check if the file altered was among the important ones
 
+	// Windows filewatcher sets "xy.json" as name, while Linux uses "./xy.json". This solves that.
+	filename = strings.ReplaceAll(filename, "./", "")
+
 	switch filename {
 
-	case "./custom_responses.json":
+	case "custom_responses.json":
 		fmt.Printf("Reloading %s. If file is malformed, old set will be kept...\n", filename)
 		err = InitCustomResponses()
 		changed = true
 		break
 
-	case "./comforts.json":
+	case "comforts.json":
 		fmt.Printf("Reloading %s. If file is malformed, old set will be kept...\n", filename)
 		err = LoadComfortsList(filename, &Comforts)
 		changed = true
 		break
 
-	case "./childcomforts.json":
+	case "childcomforts.json":
 		fmt.Printf("Reloading %s. If file is malformed, old set will be kept...\n", filename)
 		err = LoadComfortsList(filename, &ChildComforts)
 		changed = true
 		break
 
-	case "./childrcomforts.json":
+	case "childrcomforts.json":
 		fmt.Printf("Reloading %s. If file is malformed, old set will be kept...\n", filename)
 		err = LoadComfortsList(filename, &ChildReverseComforts)
 		changed = true

--- a/state.go
+++ b/state.go
@@ -6,6 +6,9 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+
+	// Used for file watching
+	"github.com/fsnotify/fsnotify"
 )
 
 func InitGlobal() {
@@ -27,6 +30,7 @@ func LoadComfortsList(filename string, list interface{}) error {
 	if err == nil {
 		dec := json.NewDecoder(f)
 		err = dec.Decode(list)
+		f.Close()
 	}
 	return err
 }
@@ -50,14 +54,14 @@ func InitComforts() {
 }
 
 // Loads custom_responses.json and parses custom responses to given user input for later use
-func InitCustomResponses() {
+func InitCustomResponses() error {
 	// Filenames could be pulled out into a config file in the long run...
 	jsonFile, err := os.Open("custom_responses.json")
 
 	// Error handling in case file does not exist
 	if err != nil {
 		fmt.Println(err, ", no custom responses were loaded. custom_responses.json might not exist.")
-		return
+		return err
 	}
 
 	// Close jsonFile as soon as this function returns
@@ -76,12 +80,93 @@ func InitCustomResponses() {
 	// Error handling in case json is invalid
 	if err != nil {
 		fmt.Println(err, ", no custom responses were loaded. custom_responses.json might be malformed.")
-		return
+		return err
 	}
 
+	CustomResponses = make(map[string]string)
 	// Make everything lowercase
 	for k, v := range temporaryMap {
 		CustomResponses[strings.Title(k)] = v
+	}
+
+	return nil
+}
+
+// Decides what to do, when certain files in the directory are altered
+func handleReload(filename string) {
+	var err error = nil      // Used for error handling/ notifying of errors
+	var changed bool = false // Used to check if the file altered was among the important ones
+
+	switch filename {
+
+	case "./custom_responses.json":
+		fmt.Printf("Reloading %s. If file is malformed, old set will be kept...\n", filename)
+		err = InitCustomResponses()
+		changed = true
+		break
+
+	case "./comforts.json":
+		fmt.Printf("Reloading %s. If file is malformed, old set will be kept...\n", filename)
+		err = LoadComfortsList(filename, &Comforts)
+		changed = true
+		break
+
+	case "./childcomforts.json":
+		fmt.Printf("Reloading %s. If file is malformed, old set will be kept...\n", filename)
+		err = LoadComfortsList(filename, &ChildComforts)
+		changed = true
+		break
+
+	case "./childrcomforts.json":
+		fmt.Printf("Reloading %s. If file is malformed, old set will be kept...\n", filename)
+		err = LoadComfortsList(filename, &ChildReverseComforts)
+		changed = true
+		break
+
+	}
+
+	if err != nil {
+		fmt.Println(err, " , file couldn't be reloaded. Staying with old contents...")
+	} else if err == nil && changed {
+		// Only print this when changed has been set true, so nothing is printed when trivial file changes occur (eg. waifus.json)
+		fmt.Println("Successfully reloaded ", filename)
+	}
+}
+
+// Attach a file watcher, so changes in configuration files can be reloaded on the go.. (no pun intended)
+func AttachWatcher() {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		fmt.Println(err, ", couldn't attach file watcher. Bot has to be restarted in case of changes..")
+		return
+	}
+
+	// Go routine. As such, this piece of code will run concurrently to the rest of the code as long as the bot is up
+	go func() {
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+				// "if the even that happened is a write to a file"
+				if event.Op&fsnotify.Write == fsnotify.Write {
+					handleReload(event.Name)
+				}
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				// Shouldn't happen, but just in case
+				fmt.Println("File Watcher Error:", err)
+			}
+		}
+	}()
+
+	//Attach the watcher to the working directory
+	err = watcher.Add("./")
+	if err != nil {
+		fmt.Println(err, ", couldn't attach file watcher. Bot has to be restarted in case of changes..")
 	}
 }
 


### PR DESCRIPTION
_Before asking... yes I was bored once again (also, this is quite some fun to be honest)_

The comfort prompts, as well as the custom resoponses are now being monitored for changes on the file, and dynamically reloaded. If the json file is invalid, eg. missing a semicolon or whatever, the contents are not loaded, and the current state of things is kept. When starting this, please remember to run `go get` again, as it uses a library from GitHub.

I have tested this under Windows and Linux, but wasn't able to do any extensive testing, but everything should work.

One small problem, without any real solution, is that some editors (especially those on Windows) tend to write to files twice per save. As such the file is reloaded twice as well, with the first reload sometimes leading to an error message being printed. This can be safely ignored, as long as one of the log entries is `Successfully reloaded` the bot did successfully reload.

An example of how such multiple write problem looks, this can be taken for reference:
```
Reloading custom_responses.json. If file is malformed, old set will be kept...
invalid character 'a' looking for beginning of object key string , no custom responses were loaded. custom_responses.json might be malformed.
invalid character 'a' looking for beginning of object key string  , file couldn't be reloaded. Staying with old contents...
Reloading custom_responses.json. If file is malformed, old set will be kept...
Successfully reloaded  custom_responses.json
```

As of now, this change does write a lot of logging information if files are changed. One might want to change this, if the log output overshadows other log output.